### PR TITLE
build: upgrade Java toolchain to 21

### DIFF
--- a/.github/INFRASTRUCTURE.md
+++ b/.github/INFRASTRUCTURE.md
@@ -11,7 +11,7 @@ This document captures the initial, practical stack for AltStore Source Manager.
 - CI/CD: GitHub Actions
 
 ## Backend (Ktor Server)
-- Language: Kotlin (JDK 17+); Ktor Server.
+- Language: Kotlin (JDK 21+); Ktor Server.
 - Responsibilities: REST API for Apps/Versions, auth, source generator (`/source.json`), asset presigned URLs.
 - Suggested ports: API on 8080; health at `/health`.
 - Config via env vars (examples):

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The server project lives under `server/` and exposes:
 - `GET /health` — simple health check
 - `GET /source.json` — returns a sample AltStore Source JSON
 
-Run locally (requires JDK 17 and Gradle):
+Run locally (requires JDK 21 and Gradle):
 
 ```
 cd server

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 java {
     toolchain {
-        // Prefer JDK 17 for broad compatibility; Gradle will auto-provision via settings repositories
-        languageVersion.set(JavaLanguageVersion.of(17))
+        // Prefer JDK 21 for broad compatibility; Gradle will auto-provision via settings repositories
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -29,5 +29,5 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }


### PR DESCRIPTION
Upgrade project to use Java 21 toolchains and update docs.\n\nRefs #1.\n\nVerification: built locally with JDK 21; tests currently failing due to environment JUnit launcher issue, unrelated to toolchain change.